### PR TITLE
Update rtty.cpp

### DIFF
--- a/rtty.cpp
+++ b/rtty.cpp
@@ -10,7 +10,13 @@
    http://www.cuspaceflight.co.uk
 */
 
+
+#if defined(ARDUINO) && ARDUINO >= 100
+#include "Arduino.h"
+#else
 #include "WProgram.h"
+#endif
+
 #include "util/crc16.h"
 #include "types.h"
 #include "rtty.h"


### PR DESCRIPTION
The Arduino 1.0 update broke this library. 
Arduino no longer ships with WProgram.h and has been replaced with Arduino.h.
